### PR TITLE
add proxy support to hpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "columnify": "^1.5.4",
     "execa": "^0.5.0",
     "file-exists": "^2.0.0",
-    "got": "^6.3.0",
-    "npm-name": "^3.0.0",
+    "got": "^6.7.1",
     "opn": "^4.0.2",
     "ora": "^0.3.0",
     "pify": "^2.3.0",
     "recast": "^0.11.10",
+    "registry-url": "^3.1.0",
+    "tunnel": "0.0.5",
     "update-notifier": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- add proxy support by removing `npm-name` dependency and resolving npm packages in the code
- add proxy settings detection through `.hpmproxy` file in `~`

proxy settings are now defined in `~/.hpmproxy` as a JS module (see documentation)